### PR TITLE
Added underscore in FD function names in fdtool

### DIFF
--- a/fdtool
+++ b/fdtool
@@ -12,7 +12,7 @@ def parse_fd(fname):
   funcs = []
   res['funcs'] = funcs
   
-  func_pat = "([A-Za-z][A-Za-z00-9]+)\((.*)\)\((.*)\)"
+  func_pat = "([A-Za-z][_A-Za-z00-9]+)\((.*)\)\((.*)\)"
   
   bias = 0
   private = True


### PR DESCRIPTION
For example exec.library FD from NDK3.9 contains AVL_AddNode etc.
