### PR TITLE
Get musashi building on Windows, works with VS2010 express now, but thes...

### DIFF
--- a/musashi/m68kconf.h
+++ b/musashi/m68kconf.h
@@ -186,7 +186,11 @@
  * NOTE: not enabling inline functions will SEVERELY slow down emulation.
  */
 #ifndef INLINE
+#ifdef _MSC_VER
+#define INLINE static __inline
+#else
 #define INLINE static __inline__
+#endif
 #endif /* INLINE */
 
 #endif /* M68K_COMPILE_FOR_MAME */

--- a/musashi/makefile.win
+++ b/musashi/makefile.win
@@ -2,7 +2,7 @@
 
 CC = cl
 SO_EXT = dll
-CFLAGS = 
+CFLAGS =
 
 SRC = mem.c m68kcpu.c m68kdasm.c
 HDR = mem.h m68k.h m68kcpu.h m68kconf.h
@@ -42,7 +42,7 @@ $(GEN_FILES): $(GEN_TOOL) $(GEN_INPUT)
 	.\$(GEN_TOOL)
 
 $(ALL_OBJ): $(ALL_SRC)
-	$(CC) /c $(ALL_SRC)
+	$(CC) /c $(CFLAGS) $(ALL_SRC)
 
 clean: clean_gen
 	del /q $(GEN_TOOL)

--- a/musashi/musashi_dll.def
+++ b/musashi/musashi_dll.def
@@ -26,8 +26,6 @@ EXPORTS
 	m68k_context_size
 	m68k_get_context
 	m68k_set_context
-	m68k_save_context
-	m68k_load_context
 	m68k_get_reg
 	m68k_set_reg
 	m68k_is_valid_instruction


### PR DESCRIPTION
Musashi did not compile on Windows, when following the instructions.

Fixes INLINE not being compatible with MSVC.  Error message observed:

`d:\vcs\git\amiga\amitools\musashi\m68kcpu.h(879) : error C2054: expected '(' to follow '__inline__'`

Fixes obsolete symbol names in the .def file used to produce the .lib.

`musashi_dll.def : error LNK2001: unresolved external symbol m68k_load_context`
`musashi_dll.def : error LNK2001: unresolved external symbol m68k_save_context`
`musashi.lib : fatal error LNK1120: 2 unresolved externals`
