### PR TITLE
KeyValue.parse_key_value_string() returns str from hex value

### DIFF
--- a/amitools/util/KeyValue.py
+++ b/amitools/util/KeyValue.py
@@ -13,8 +13,6 @@ def parse_key_value_string(s, d):
       value = True
     elif v in ("false","off"):
       value = False
-    elif v.startswith("0x"):
-      value = int(v[2:],16)
     else:
       # try a value
       try:
@@ -29,4 +27,4 @@ def parse_key_value_strings(strs):
   for s in strs:
     parse_key_value_string(s, result)
   return result
-  
+


### PR DESCRIPTION
This fixes AttributeError if "dostype=" argument is given, eg:
```
rdbtool test.rdb create size=10M + init + add size=50% dostype=0x50465303
```