### PR TITLE
Fixed an off-by-one error in the ReadArgs emulation.

### DIFF
--- a/amitools/vamos/lib/dos/Args.py
+++ b/amitools/vamos/lib/dos/Args.py
@@ -51,7 +51,7 @@ class Args:
       if extra:
         # last one? -> failed to get extra arg
         n = len(in_list)
-        if pos == n-1:
+        if pos == n: # THOR: off-by-one error, note that in_list is now one element shorter
           return None
         val = in_list[pos]
         in_list.pop(pos)


### PR DESCRIPTION
This seems to fix the bug for the bug report I submitted yesterday - hopefully. It seems to be an off-by-one error in the ReadArgs() emulation. Fixes "copy abc TO def", with the "to" keyword present.
