### PR TITLE
A big bunch of fixes...

### DIFF
--- a/amitools/vamos/Process.py
+++ b/amitools/vamos/Process.py
@@ -15,7 +15,7 @@ class Process:
     if not self.ok:
       return
     self.init_stack(stack_size, exit_addr)
-    self.init_args(bin_args)
+    self.init_args(bin_args,input_fh)
     self.init_cli_struct(input_fh, output_fh)
     self.init_task_struct(input_fh, output_fh)
 
@@ -78,7 +78,7 @@ class Process:
       return arg
     
   # ----- args -----
-  def init_args(self, bin_args):
+  def init_args(self, bin_args, fh):
     # setup arguments
     self.bin_args = bin_args
     text_args = ""
@@ -88,9 +88,9 @@ class Process:
         text_args = text_args + " "
       text_args = text_args + self.quote_arg(arg)
       gap = True
-    print "Text args are "+text_args
     self.arg_text = text_args + "\n" # AmigaDOS appends a new line to the end
     self.arg_len  = len(self.arg_text)
+    fh.setbuf(self.arg_text) # Tripos makes the input line available as buffered input for ReadItem()
     self.arg_size = self.arg_len + 1
     self.arg = self.ctx.alloc.alloc_memory(self.bin_basename + "_args", self.arg_size)
     self.arg_base = self.arg.addr
@@ -124,7 +124,7 @@ class Process:
   # ----- task struct -----
   def init_task_struct(self, input_fh, output_fh):
     # Inject arguments into input stream (Needed for C:Execute)
-    input_fh.ungets(self.arg_text)
+    #input_fh.ungets(self.arg_text)
     self.this_task = self.ctx.alloc.alloc_struct(self.bin_basename + "_ThisTask",ProcessDef)
     self.this_task.access.w_s("pr_Task.tc_Node.ln_Type", NT_PROCESS)
     self.this_task.access.w_s("pr_CLI", self.cli.addr)

--- a/amitools/vamos/Process.py
+++ b/amitools/vamos/Process.py
@@ -67,11 +67,29 @@ class Process:
   def unload_binary(self):
     self.ctx.seg_loader.unload_seg(self.bin_seg_list)
 
+  def quote_arg(self,arg):
+    if " " in arg or arg == "":
+      out=arg.replace("*","**")
+      out=out.replace("\e","*e")
+      out=out.replace("\n","*n")
+      out=out.replace("\"","*\"")
+      return "\""+out+"\""
+    else:
+      return arg
+    
   # ----- args -----
   def init_args(self, bin_args):
     # setup arguments
     self.bin_args = bin_args
-    self.arg_text = " ".join(bin_args) + "\n" # AmigaDOS appends a new line to the end
+    text_args = ""
+    gap = False
+    for arg in bin_args:
+      if gap:
+        text_args = text_args + " "
+      text_args = text_args + self.quote_arg(arg)
+      gap = True
+    print "Text args are "+text_args
+    self.arg_text = text_args + "\n" # AmigaDOS appends a new line to the end
     self.arg_len  = len(self.arg_text)
     self.arg_size = self.arg_len + 1
     self.arg = self.ctx.alloc.alloc_memory(self.bin_basename + "_args", self.arg_size)

--- a/amitools/vamos/lib/ExecLibrary.py
+++ b/amitools/vamos/lib/ExecLibrary.py
@@ -278,3 +278,27 @@ class ExecLibrary(AmigaLibrary):
     AccessStruct(ctx.mem, NodeDef, succ).w_s("ln_Pred", pred)
     return node_addr
 
+  def CopyMem(self, ctx):
+    source = ctx.cpu.r_reg(REG_A0)
+    dest   = ctx.cpu.r_reg(REG_A1)
+    len    = ctx.cpu.r_reg(REG_D0)
+    log_exec.info("CopyMem: source=%06x dest=%06x len=%06x" % (source,dest,len))
+    while len > 0:
+      ctx.mem.access.w8(dest,ctx.mem.access.r8(source))
+      dest   = dest   + 1
+      source = source + 1
+      len    = len    - 1
+
+  def CopyMemQuick(self, ctx):
+    source = ctx.cpu.r_reg(REG_A0)
+    dest   = ctx.cpu.r_reg(REG_A1)
+    len    = ctx.cpu.r_reg(REG_D0)
+    log_exec.info("CopyMemQuick: source=%06x dest=%06x len=%06x" % (source,dest,len))
+    while len > 0:
+      ctx.mem.access.w32(dest,ctx.mem.access.r32(source))
+      dest   = dest   + 4
+      source = source + 4
+      len    = len    - 4
+
+
+

--- a/amitools/vamos/lib/dos/Args.py
+++ b/amitools/vamos/lib/dos/Args.py
@@ -155,6 +155,7 @@ class Args:
     # scan for multi and non-key args
     multi_pos = None
     multi_targ = None
+    
     pos = 0
     for targ in targs:
       # multi

--- a/amitools/vamos/lib/dos/DosList.py
+++ b/amitools/vamos/lib/dos/DosList.py
@@ -19,6 +19,13 @@ class DosList:
     self.entries_by_name = {}
     self.entries = []
 
+  def __str__(self):
+    res = "["
+    for en in self.entries:
+      res = res + en.__str__()
+    res = res + "]"
+    return res
+
   def build_list(self, path_mgr):
     """build the dos list and return a bptr of the first entry"""
     # fill dos list

--- a/amitools/vamos/lib/dos/DosStruct.py
+++ b/amitools/vamos/lib/dos/DosStruct.py
@@ -299,3 +299,21 @@ class DateTimeStruct(AmigaStruct):
     ('UBYTE*','dat_StrTime')
   ]
 DateTimeDef = DateTimeStruct()
+
+class InfoDataStruct(AmigaStruct):
+  _name = "InfoData"
+  _format = [
+    ('LONG','id_NumSoftErrors'),
+    ('LONG','id_UnitNumber'),
+    ('LONG','id_DiskState'),
+    ('LONG','id_NumBlocks'),
+    ('LONG','id_NumBlocksUsed'),
+    ('LONG','id_BytesPerBlock'),
+    ('LONG','id_DiskType'),
+    ('BPTR','id_VolumeNode'),
+    ('LONG','id_InUse')
+    ]
+InfoDataDef = InfoDataStruct()
+
+
+    

--- a/amitools/vamos/lib/dos/FileHandle.py
+++ b/amitools/vamos/lib/dos/FileHandle.py
@@ -13,7 +13,7 @@ class FileHandle:
     self.b_addr = 0
     self.need_close = need_close
     # buffering
-    self.unch = ''
+    self.unch = ""
     self.ch = -1
 
   def __str__(self):
@@ -69,6 +69,9 @@ class FileHandle:
   def ungets(self, s):
     self.unch = self.unch + s
 
+  def setbuf(self,s):
+    self.unch = s
+    
   def tell(self):
     return self.obj.tell()
 

--- a/amitools/vamos/lib/dos/FileManager.py
+++ b/amitools/vamos/lib/dos/FileManager.py
@@ -74,7 +74,7 @@ class FileManager:
         fh = FileHandle(sys.stdout,'*','',need_close=False)
       else:
         # map to system path
-        sys_path = self.path_mgr.ami_to_sys_path(ami_path)
+        sys_path = self.path_mgr.ami_to_sys_path(ami_path,searchMulti=True)
         if sys_path == None:
           log_file.info("file not found: '%s' -> '%s'" % (ami_path, sys_path))
           return None

--- a/amitools/vamos/lib/dos/FileManager.py
+++ b/amitools/vamos/lib/dos/FileManager.py
@@ -63,11 +63,13 @@ class FileManager:
     try:
       # special names
       uname = ami_path.upper()
-      if uname == 'NIL:':
+      # thor: NIL: and CONSOLE: also work as device names
+      # and the file names behind are ignored.
+      if uname.startswith('NIL:'):
         sys_name = "/dev/null"
         fobj = open(sys_name, f_mode)
         fh = FileHandle(fobj, ami_path, sys_name)
-      elif uname in ('*','CONSOLE:'):
+      elif uname == '*' or uname.startswith('CONSOLE:'):
         sys_name = ''
         fh = FileHandle(sys.stdout,'*','',need_close=False)
       else:

--- a/amitools/vamos/lib/dos/LockManager.py
+++ b/amitools/vamos/lib/dos/LockManager.py
@@ -46,6 +46,7 @@ class LockManager:
 
   def create_lock(self, ami_path, exclusive):
     if ami_path == '':
+      #ami_path = self.path_mgr.ami_abs_path('.')
       ami_path = self.path_mgr.ami_abs_cur_path()
     else:
       ami_path = self.path_mgr.ami_abs_path(ami_path)

--- a/amitools/vamos/lib/dos/LockManager.py
+++ b/amitools/vamos/lib/dos/LockManager.py
@@ -10,12 +10,13 @@ from Error import *
 from Lock import Lock
 
 class LockManager:
-  def __init__(self, path_mgr, dos_list, alloc):
+  def __init__(self, path_mgr, dos_list, alloc, mem):
     self.path_mgr = path_mgr
     self.dos_list = dos_list
-    self.alloc = alloc
+    self.alloc    = alloc
+    self.mem      = mem
 
-    self.locks_by_b_addr = {}
+    self.locks_by_key = {}
 
   def _register_lock(self, lock):
     # look up volume
@@ -29,16 +30,16 @@ class LockManager:
       vol_baddr = volume.baddr
     # allocate lock struct
     b_addr = lock.alloc(self.alloc, vol_baddr)
-    self.locks_by_b_addr[b_addr] = lock
+    self.locks_by_key[lock.key] = lock
     log_lock.info("registered: %s" % lock)
 
   def _unregister_lock(self, lock):
-    if not self.locks_by_b_addr.has_key(lock.b_addr):
+    if not self.locks_by_key.has_key(lock.key):
       raise VamosInternalError("Lock %s not registered!" % lock)
-    check = self.locks_by_b_addr[lock.b_addr]
+    check = self.locks_by_key[lock.key]
     if check != lock:
       raise VamosInternalError("Invalid Lock unregistered: %s" % lock)
-    del self.locks_by_b_addr[lock.b_addr]
+    del self.locks_by_key[lock.key]
     log_lock.info("unregistered: %s" % lock)
     lock.b_addr = 0
     lock.addr = 0
@@ -46,11 +47,10 @@ class LockManager:
 
   def create_lock(self, ami_path, exclusive):
     if ami_path == '':
-      #ami_path = self.path_mgr.ami_abs_path('.')
       ami_path = self.path_mgr.ami_abs_cur_path()
     else:
       ami_path = self.path_mgr.ami_abs_path(ami_path)
-    sys_path = self.path_mgr.ami_to_sys_path(ami_path)
+    sys_path = self.path_mgr.ami_to_sys_path(ami_path,searchMulti=True)
     name = self.path_mgr.ami_name_of_path(ami_path)
     if sys_path == None:
       log_lock.info("lock '%s' invalid: no sys path found: '%s'", name, ami_path)
@@ -74,6 +74,10 @@ class LockManager:
     else:
       return None
 
+  def _get_key_from_baddr(self, b_addr):
+    addr = b_addr << 2
+    return self.mem.access.r32(addr + 4)
+
   def get_by_b_addr(self, b_addr, none_if_missing=False):
     # current dir lock
     if b_addr == 0:
@@ -81,8 +85,9 @@ class LockManager:
       ami_path = cur_dev + ":" + cur_path
       sys_path = self.path_mgr.ami_to_sys_path(ami_path)
       return Lock("local",ami_path,sys_path)
-    elif self.locks_by_b_addr.has_key(b_addr):
-      return self.locks_by_b_addr[b_addr]
+    elif self.locks_by_key.has_key(self._get_key_from_baddr(b_addr)):
+      lock = self.locks_by_key[self._get_key_from_baddr(b_addr)]
+      return lock
     else:
       if none_if_missing:
         return None

--- a/amitools/vamos/lib/dos/MatchFirstNext.py
+++ b/amitools/vamos/lib/dos/MatchFirstNext.py
@@ -35,7 +35,6 @@ class MatchFirstNext:
     if self.path == None:
       return ERROR_OBJECT_NOT_FOUND
     self.name = self.path_mgr.ami_name_of_path(self.path)
-
     # get parent dir of first match
     dir_part = self.path_mgr.ami_dir_of_path(self.path)
     abs_path = self.path_mgr.ami_abs_path(dir_part)

--- a/amitools/vamos/path/PathManager.py
+++ b/amitools/vamos/path/PathManager.py
@@ -192,6 +192,7 @@ class PathManager:
     if path == "":
       return self.cur_vol + ":" + self.cur_path
     col_pos = path.find(':')
+    #print path,col_pos
     # already with device name
     if col_pos > 0:
       return path
@@ -253,24 +254,27 @@ class PathManager:
       return ""
     # ends with volume
     p = path
+    vol = ""
     if p[-1] == ':':
       return ""
     # skip volume
     col_pos = p.find(':')
     if col_pos :
+      vol = p[:col_pos+1]
       p = p[col_pos+1:]
       l = len(path)
       if l > 0 and p[0] == '/':
         p = p[1:]
-    # find slash
+    # find slash, also add
+    # the volume again.
     slash_pos = p.rfind('/')
     if slash_pos == -1:
-      return ""
+      return vol+""
     else:
       if slash_pos == 0:
-        return "/"
+        return vol+"/"
       else:
-        return p[:slash_pos]
+        return vol+p[:slash_pos]
 
   def ami_volume_of_path(self, path):
     pos = path.find(':')


### PR DESCRIPTION
Many fixes in here:

Open(): CONSOLE:afilename and NIL:afilename are valid AmigaOs paths and should open files to * and /dev/null

Lock() and Open() did not handle multi-assigns correctly (searchMulti must be set to true)

ExNext() had a broken initialization to dirent, should be set to None, not [] to make it work.

SystemTagList() must re-quote its arguments to be able to handle arguments with blanks or empty arguments. (Actually, the AmigaShell works a bit different, but no matter at this point)

RunCommand() as in SystemTagList() does not *append* to the input buffer, but rather sets it. This broke C:Execute in scripts when an empty \n was still present in the buffer.

DirPart() cut off the volume name.

Info() was not implemented at all.

CopyMem() and CopyMemQuick() were not implemented at all.

Pending bugs:
-Assigns do not create entries in the DosList, though should.
-Locks should not be identified by their lock value. In fact, Examine and ExNext should *only* depend on fib_Key. Ugly, unfortunate, but true.
- SystemTagList does not find shell built-ins, most notably "CD".
