### PR TITLE
Fix blocks per track/cylinder mixup

### DIFF
--- a/amitools/fs/rdb/RDisk.py
+++ b/amitools/fs/rdb/RDisk.py
@@ -360,7 +360,7 @@ class RDisk:
     pb = PartitionBlock(self.rawblk, blk_num)
     # setup dos env
     heads = self.rdb.phy_drv.heads
-    blk_per_trk = self.rdb.phy_drv.secs * heads
+    blk_per_trk = self.rdb.phy_drv.secs
     dos_env = PartitionDosEnv(low_cyl=cyl_range[0], high_cyl=cyl_range[1], surfaces=heads, \
                               blk_per_trk=blk_per_trk, dos_type=dos_type, boot_pri=boot_pri)
     self._adjust_dos_env(dos_env, more_dos_env)
@@ -380,7 +380,8 @@ class RDisk:
     # flush out all changes before we read again
     self.rawblk.flush()
     # create partition object and add to partition list
-    p = Partition(self.rawblk, blk_num, len(self.parts), blk_per_trk, self)
+    blk_per_cyl = blk_per_trk * heads
+    p = Partition(self.rawblk, blk_num, len(self.parts), blk_per_cyl, self)
     p.read()
     self.parts.append(p)
     return True


### PR DESCRIPTION
Issue #25 reported that partitions were being created with the wrong size due to `heads` not being involved in the calculation. Commit 088a3dd attempted to fix this but introduced a different error; the partition table appeared correctly, but when trying to format the partition on a real Amiga, the `format` command would fail.

The root cause is that the `PartitionDosEnv` object wants to know about blocks per track, but the `Partition` object wants to know about blocks per cylinder. The code was trying to use the same value for both. Hence the commit for issue #25 fixed one problem but introduced a new problem elsewhere.

This fix correctly uses blocks per track and blocks per cylinder on the right objects.