### PR TITLE
Tiny fixes in LoadSeg(), fixes in parent path, fixes in console I/O, SystemTagList()

### DIFF
--- a/amitools/vamos/LibManager.py
+++ b/amitools/vamos/LibManager.py
@@ -275,7 +275,7 @@ class LibManager():
     end = time.clock()
     delta = end - start;
     if res_list == None or len(res_list) != 1:
-      self.lib_log("load_lib","No single resident found!", level=logging.ERROR)
+      self.lib_log("load_lib","No single resident in %s found found!" % load_name, level=logging.ERROR)
       return None
 
     # make sure its a library

--- a/amitools/vamos/SegmentLoader.py
+++ b/amitools/vamos/SegmentLoader.py
@@ -56,9 +56,12 @@ class SegmentLoader:
     return self.path_mgr.ami_command_to_sys_path(lock, ami_bin_file) != None
 
   # load ami_bin_file
-  def load_seg(self, lock, ami_bin_file, allow_reuse = True):
+  def load_seg(self, lock, ami_bin_file, allow_reuse = True, local_path = False):
     # map file name
-    sys_bin_file = self.path_mgr.ami_command_to_sys_path(lock, ami_bin_file)
+    if local_path:
+      sys_bin_file = self.path_mgr.ami_to_sys_path(lock,ami_bin_file,searchMulti=True)
+    else:
+      sys_bin_file = self.path_mgr.ami_command_to_sys_path(lock, ami_bin_file)
     if sys_bin_file == None:
       self.error = "failed mapping binary path: '%s'" % ami_bin_file
       return None

--- a/amitools/vamos/lib/DosLibrary.py
+++ b/amitools/vamos/lib/DosLibrary.py
@@ -427,13 +427,13 @@ class DosLibrary(AmigaLibrary):
 
   def SelectInput(self, ctx):
     fh_b_addr = ctx.cpu.r_reg(REG_D1)
-    fh = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh = self.file_mgr.get_by_b_addr(fh_b_addr,False)
     log_dos.info("SelectInput(fh=%s)" % fh)
     ctx.process.set_input(fh)
 
   def SelectOutput(self, ctx):
     fh_b_addr = ctx.cpu.r_reg(REG_D1)
-    fh = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh = self.file_mgr.get_by_b_addr(fh_b_addr,True)
     log_dos.info("SelectOutput(fh=%s)" % fh)
     ctx.process.set_output(fh)
 
@@ -477,7 +477,7 @@ class DosLibrary(AmigaLibrary):
     buf_ptr = ctx.cpu.r_reg(REG_D2)
     size = ctx.cpu.r_reg(REG_D3)
 
-    fh = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh = self.file_mgr.get_by_b_addr(fh_b_addr,False)
     data = fh.read(size)
     ctx.mem.access.w_data(buf_ptr, data)
     got = len(data)
@@ -489,7 +489,7 @@ class DosLibrary(AmigaLibrary):
     buf_ptr = ctx.cpu.r_reg(REG_D2)
     size = ctx.cpu.r_reg(REG_D3)
 
-    fh = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh = self.file_mgr.get_by_b_addr(fh_b_addr,True)
     data = ctx.mem.access.r_data(buf_ptr,size)
     fh.write(data)
     got = len(data)
@@ -503,7 +503,7 @@ class DosLibrary(AmigaLibrary):
     number = ctx.cpu.r_reg(REG_D4)
     # Actually, this is buffered I/O, not unbuffered IO. For the
     # time being, keep it unbuffered.
-    fh = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh = self.file_mgr.get_by_b_addr(fh_b_addr,True)
     data = ctx.mem.access.r_data(buf_ptr,size * number)
     fh.write(data)
     got = len(data) / size
@@ -535,7 +535,7 @@ class DosLibrary(AmigaLibrary):
 
   def FGetC(self, ctx):
     fh_b_addr = ctx.cpu.r_reg(REG_D1)
-    fh = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh = self.file_mgr.get_by_b_addr(fh_b_addr,False)
     ch = fh.getc()
     if ch == -1:
       log_dos.info("FGetC(%s) -> EOF (%d)" % (fh, ch))
@@ -546,7 +546,7 @@ class DosLibrary(AmigaLibrary):
   def FPutC(self, ctx):
     fh_b_addr = ctx.cpu.r_reg(REG_D1)
     val = ctx.cpu.r_reg(REG_D2)
-    fh = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh = self.file_mgr.get_by_b_addr(fh_b_addr,True)
     log_dos.info("FPutC(%s, '%c' (%d))" % (fh, val, val))
     fh.write(chr(val))
     return val
@@ -554,7 +554,7 @@ class DosLibrary(AmigaLibrary):
   def UnGetC(self, ctx):
     fh_b_addr = ctx.cpu.r_reg(REG_D1)
     val = ctx.cpu.r_reg(REG_D2)
-    fh = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh = self.file_mgr.get_by_b_addr(fh_b_addr,False)
     ch = fh.ungetc(val)
     log_dos.info("UnGetC(%s, %d) -> ch=%c (%d)" % (fh, val, ch, ch))
     return ch
@@ -572,7 +572,7 @@ class DosLibrary(AmigaLibrary):
 
   def Flush(self, ctx):
     fh_b_addr = ctx.cpu.r_reg(REG_D1)
-    fh = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh = self.file_mgr.get_by_b_addr(fh_b_addr,True)
     fh.flush()
     return -1
 
@@ -594,7 +594,7 @@ class DosLibrary(AmigaLibrary):
 
   def VFPrintf(self, ctx):
     fh_b_addr = ctx.cpu.r_reg(REG_D1)
-    fh = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh = self.file_mgr.get_by_b_addr(fh_b_addr,True)
     format_ptr = ctx.cpu.r_reg(REG_D2)
     argv_ptr = ctx.cpu.r_reg(REG_D3)
     fmt = ctx.mem.access.r_cstr(format_ptr)
@@ -619,7 +619,7 @@ class DosLibrary(AmigaLibrary):
 
   def VFWritef(self, ctx):
     fh_b_addr = ctx.cpu.r_reg(REG_D1)
-    fh = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh = self.file_mgr.get_by_b_addr(fh_b_addr,True)
     fmt_ptr = ctx.cpu.r_reg(REG_D2)
     args_ptr = ctx.cpu.r_reg(REG_D3)
     fmt = ctx.mem.access.r_cstr(fmt_ptr)
@@ -685,7 +685,7 @@ class DosLibrary(AmigaLibrary):
     fh_b_addr = ctx.cpu.r_reg(REG_D1)
     bufaddr   = ctx.cpu.r_reg(REG_D2)
     buflen    = ctx.cpu.r_reg(REG_D3)
-    fh   = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh   = self.file_mgr.get_by_b_addr(fh_b_addr,False)
     line = fh.gets(buflen)
     log_dos.info("FGetS(%s,%d) -> '%s'" % (fh, buflen, line))
     ctx.mem.access.w_cstr(bufaddr,line)
@@ -732,7 +732,7 @@ class DosLibrary(AmigaLibrary):
 
   def IsInteractive(self, ctx):
     fh_b_addr = ctx.cpu.r_reg(REG_D1)
-    fh = self.file_mgr.get_by_b_addr(fh_b_addr)
+    fh = self.file_mgr.get_by_b_addr(fh_b_addr,False)
     res = fh.is_interactive()
     log_dos.info("IsInteractive(%s): %s" % (fh, res))
     if res:
@@ -1270,7 +1270,7 @@ class DosLibrary(AmigaLibrary):
         new_input.setbuf(cmd)
       else:
         inputfh   = cli.r_s("cli_CurrentInput")
-        new_input = self.file_mgr.get_by_b_addr(inputfh >> 2)
+        new_input = self.file_mgr.get_by_b_addr(inputfh >> 2,False)
         cmd       = cmd + "\n" + new_input.getbuf()
         new_input.setbuf(cmd)
       new_stdin = self.file_mgr.open(None,"*","rw")
@@ -1301,7 +1301,7 @@ class DosLibrary(AmigaLibrary):
         cli.w_s("cli_Module",cur_module)
         ctx.mem.access.w_bstr(cli.r_s("cli_SetName"),cur_setname)
         ctx.process.this_task.access.w_s("pr_CIS",input_fh)
-        infile = self.file_mgr.get_by_b_addr(input_fh >> 2)
+        infile = self.file_mgr.get_by_b_addr(input_fh >> 2,False)
         infile.setbuf("")
         self.ctx.process.set_current_dir(current_dir)
         self.cur_dir_lock = self.lock_mgr.get_by_b_addr(current_dir >> 2)

--- a/amitools/vamos/lib/DosLibrary.py
+++ b/amitools/vamos/lib/DosLibrary.py
@@ -1261,23 +1261,18 @@ class DosLibrary(AmigaLibrary):
     if ctx.process.is_native_shell():
       cli_addr = ctx.process.get_cli_struct()
       cli      = AccessStruct(ctx.mem,CLIDef,struct_addr=cli_addr)
-      if cli.r_s("cli_CurrentInput") == cli.r_s("cli_StandardInput"):
-        new_input = self.file_mgr.open(None,"NIL:","r")
-        if new_input == None:
-          log_dos.warn("SystemTagList: can't create new input file handle for SystemTagList('%s')", cmd)
-          return 0xffffffff
-        #Push-back the commands into the input buffer.
-        new_input.setbuf(cmd)
-      else:
-        inputfh   = cli.r_s("cli_CurrentInput")
-        new_input = self.file_mgr.get_by_b_addr(inputfh >> 2,False)
-        cmd       = cmd + "\n" + new_input.getbuf()
-        new_input.setbuf(cmd)
+      new_input = self.file_mgr.open(None,"NIL:","r")
+      if new_input == None:
+        log_dos.warn("SystemTagList: can't create new input file handle for SystemTagList('%s')", cmd)
+        return 0xffffffff
+      #Push-back the commands into the input buffer.
+      new_input.setbuf(cmd)
       new_stdin = self.file_mgr.open(None,"*","rw")
       # print "setting new input to %s" % new_input
       # and install this as current input. The shell will read from that
       # instead until it hits the EOF
-      input_fh    = cli.r_s("cli_StandardInput")
+      input_fhsi  = cli.r_s("cli_StandardInput")
+      input_fhci  = cli.r_s("cli_CurrentInput")
       cli.w_s("cli_CurrentInput",new_input.mem.addr)
       cli.w_s("cli_StandardInput",new_stdin.mem.addr)
       cli.w_s("cli_Background",self.DOSTRUE)
@@ -1295,14 +1290,15 @@ class DosLibrary(AmigaLibrary):
       # print "*** Current input is %s" % input_fh
       # trap to clean up sub process resources
       def trap_stop_run_command(ret_code):
-        cli.w_s("cli_CurrentInput",input_fh)
-        cli.w_s("cli_StandardInput",input_fh)
+        cli.w_s("cli_CurrentInput",input_fhci)
+        cli.w_s("cli_StandardInput",input_fhsi)
         cli.w_s("cli_Background",self.DOSFALSE)
         cli.w_s("cli_Module",cur_module)
+        # Channels are closed by the dying shell
         ctx.mem.access.w_bstr(cli.r_s("cli_SetName"),cur_setname)
-        ctx.process.this_task.access.w_s("pr_CIS",input_fh)
-        infile = self.file_mgr.get_by_b_addr(input_fh >> 2,False)
-        infile.setbuf("")
+        ctx.process.this_task.access.w_s("pr_CIS",input_fhci)
+        #infile = self.file_mgr.get_by_b_addr(input_fhci >> 2,False)
+        #infile.setbuf("")
         self.ctx.process.set_current_dir(current_dir)
         self.cur_dir_lock = self.lock_mgr.get_by_b_addr(current_dir >> 2)
         ctx.cpu.w_reg(REG_D0,0)

--- a/amitools/vamos/lib/DosLibrary.py
+++ b/amitools/vamos/lib/DosLibrary.py
@@ -1337,7 +1337,7 @@ class DosLibrary(AmigaLibrary):
     name_ptr = ctx.cpu.r_reg(REG_D1)
     name     = ctx.mem.access.r_cstr(name_ptr)
     lock     = self.get_current_dir()
-    seg_list = self.ctx.seg_loader.load_seg(lock,name,False)
+    seg_list = self.ctx.seg_loader.load_seg(lock,name,False,True)
     if seg_list == None:
       log_dos.warn("LoadSeg: '%s' -> not found!" % (name))
       return 0

--- a/amitools/vamos/lib/dos/FileHandle.py
+++ b/amitools/vamos/lib/dos/FileHandle.py
@@ -41,12 +41,18 @@ class FileHandle:
   # --- file ops ---
 
   def write(self, data):
-    self.obj.write(data)
-    return len(data)
+    try:
+      self.obj.write(data)
+      return len(data)
+    except IOError:
+      return -1
 
   def read(self, len):
-    d = self.obj.read(len)
-    return d
+    try:
+      d = self.obj.read(len)
+      return d
+    except IOError:
+      return -1
 
   def getc(self):
     if len(self.unch) > 0:
@@ -55,8 +61,11 @@ class FileHandle:
     else:
       if self.is_nil:
         return -1
-      d = self.obj.read(1)
-      if d == "":
+      try:
+        d = self.obj.read(1)
+        if d == "":
+          return -1
+      except IOError:
         return -1
     self.ch = ord(d)
     return self.ch
@@ -109,7 +118,10 @@ class FileHandle:
     return self.obj.tell()
 
   def seek(self, pos, whence):
-    self.obj.seek(pos, whence)
+    try:
+      self.obj.seek(pos, whence)
+    except IOError:
+      return -1
 
   def flush(self):
     self.obj.flush()

--- a/amitools/vamos/lib/dos/FileManager.py
+++ b/amitools/vamos/lib/dos/FileManager.py
@@ -104,11 +104,18 @@ class FileManager:
     fh.close()
     self._unregister_file(fh)
 
-  def get_by_b_addr(self, b_addr):
+  def get_by_b_addr(self, b_addr, for_writing = None):
     if b_addr == 0:
       return None
     if b_addr in self.files_by_b_addr:
-      return self.files_by_b_addr[b_addr]
+      fh = self.files_by_b_addr[b_addr]
+      # AmigaDos has no problem reading from an output console handle
+      # or writing to the input handle for the console.
+      if for_writing == True and fh.obj == sys.stdin:
+        return self.std_output
+      elif for_writing == False and fh.obj == sys.stdout:
+        return self.std_input
+      return fh
     else:
       addr = b_addr << 2
       raise ValueError("Invalid File Handle at b@%06x = %06x" % (b_addr, addr))

--- a/amitools/vamos/lib/dos/MatchFirstNext.py
+++ b/amitools/vamos/lib/dos/MatchFirstNext.py
@@ -39,7 +39,7 @@ class MatchFirstNext:
     # get parent dir of first match
     dir_part = self.path_mgr.ami_dir_of_path(self.lock,self.path)
     abs_path = self.path_mgr.ami_abs_path(self.lock,dir_part)
-
+    
     # create base/last achain and set dir lock
     # THOR: this is still screwed up. Some utililties
     # most notably "dir" depend on a correctly setup
@@ -84,13 +84,7 @@ class MatchFirstNext:
     return True
 
   def _fill_parent_lock(self, path):
-    slash  = path.rfind('/')
-    if slash > 0:
-      parent = path[0:slash]
-    elif slash == 0:
-      parent = "/"
-    else:
-      parent = ""
+    parent = self.path_mgr.ami_abs_parent_path(path)
     return self._fill_lock(parent)
 
   def _push_dodir(self, name, path):

--- a/amitools/vamos/path/PathManager.py
+++ b/amitools/vamos/path/PathManager.py
@@ -154,10 +154,10 @@ class PathManager:
   def ami_abs_parent_path(self, path):
     """return absolute parent path of given path or same if already parent"""
     # can't strip from device prefix
-    if path[-1] == ':':
+    if len(path) > 0 and path[-1] == ':':
       return path
     # skip trailing slash, then recursively call self
-    if path[-1] == '/':
+    if len(path) > 0 and path[-1] == '/':
       return self.ami_abs_parent_path(path[:-1])
     pos = path.rfind('/')
     # skip last part if we have parts
@@ -168,9 +168,10 @@ class PathManager:
       pos = path.find(':')
       if pos > 0:
         return path[0:pos+1]
+      elif len(path) > 0:
+        return ""
       else:
-        return path+"//"
-      
+        return "/"
 
   def ami_abs_path(self, lock, path):
     """return absolute amiga path from given path"""

--- a/musashi/Makefile
+++ b/musashi/Makefile
@@ -1,7 +1,7 @@
 # Makefile for musashi
 
-#CFLAGS    = -O0 -ggdb3
-CFLAGS    = -O3
+CFLAGS    = -O0 -ggdb3
+#CFLAGS    = -O3
 
 GEN_INPUT = m68k_in.c
 


### PR DESCRIPTION
A couple of left-over fixes:
* LoadSeg(): If run in native shell mode, this should really only load from the current directory. Added a flag for that.
* parent path computation: The pattern matcher now uses the file manager to compute the parent path. The parent path computation there failed if the path consisted only of a single directory name or was empty.
* console I/O: AmigaOs (or rather, the console) has no problems reading from stdout or printing to stdin (the console does not mind). Unfortunately, python does care, so added a workaround to allow that.
* SystemTagList(): Left over commands in the backup buffer of the input caused a mess-up in complex make-files.
