### PR TITLE
Initial support for the FS variants that support longer filenames

### DIFF
--- a/amitools/fs/ADFSDir.py
+++ b/amitools/fs/ADFSDir.py
@@ -25,7 +25,7 @@ class ADFSDir(ADFSNode):
       return "[Dir]"
   
   def blocks_create_old(self, anon_blk):
-    ud = UserDirBlock(self.blkdev, anon_blk.blk_num)
+    ud = UserDirBlock(self.blkdev, anon_blk.blk_num, self.volume.is_longname)
     ud.set(anon_blk.data)
     if not ud.valid:
       raise FSError(INVALID_USER_DIR_BLOCK, block=anon_blk)
@@ -126,7 +126,7 @@ class ADFSDir(ADFSNode):
     blk_num = free_blks[0]
     blkdev = self.blkdev
     # create a UserDirBlock
-    ud = UserDirBlock(blkdev, blk_num)
+    ud = UserDirBlock(blkdev, blk_num, self.volume.is_longname)
     ud.create(parent_blk, name.get_ami_str(), meta_info.get_protect(), meta_info.get_comment_ami_str(), meta_info.get_mod_ts(), hash_chain_blk)
     ud.write()    
     self.set_block(ud)
@@ -147,7 +147,7 @@ class ADFSDir(ADFSNode):
       meta_info.set_current_as_mod_time()
       meta_info.set_default_protect()
     # check file name
-    fn = FileName(name, is_intl=self.volume.is_intl)
+    fn = FileName(name, is_intl=self.volume.is_intl,is_longname=self.volume.is_longname)
     if not fn.is_valid():
       raise FSError(INVALID_FILE_NAME, file_name=name, node=self)
     # does already exist an entry in this dir with this name?

--- a/amitools/fs/ADFSFile.py
+++ b/amitools/fs/ADFSFile.py
@@ -1,3 +1,4 @@
+from block.EntryBlock import EntryBlock
 from block.FileHeaderBlock import FileHeaderBlock
 from block.FileListBlock import FileListBlock
 from block.FileDataBlock import FileDataBlock
@@ -22,7 +23,7 @@ class ADFSFile(ADFSNode):
   
   def blocks_create_old(self, anon_blk):
     # create file header block
-    fhb = FileHeaderBlock(self.blkdev, anon_blk.blk_num)
+    fhb = FileHeaderBlock(self.blkdev, anon_blk.blk_num, self.volume.is_longname)
     fhb.set(anon_blk.data)
     if not fhb.valid:
       raise FSError(INVALID_FILE_HEADER_BLOCK, block=anon_blk)
@@ -58,6 +59,8 @@ class ADFSFile(ADFSNode):
 
     # calc number of total blocks occupied by this file
     self.total_blks = 1 + my_num_ext_blks + my_num_data_blks
+    if self.block.comment_block_id != 0:
+        self.total_blks += 1
 
     return fhb
   
@@ -169,7 +172,7 @@ class ADFSFile(ADFSNode):
     ppb = self.volume.blkdev.block_longs - 56 # data pointer per block
     
     # create file header block
-    fhb = FileHeaderBlock(self.blkdev, fhb_num)
+    fhb = FileHeaderBlock(self.blkdev, fhb_num, self.volume.is_longname)
     byte_size = len(self.data)
     if self.num_data_blks > ppb:
       hdr_blks = self.data_blk_nums[0:ppb]

--- a/amitools/fs/DosType.py
+++ b/amitools/fs/DosType.py
@@ -7,6 +7,8 @@ DOS2 = 0x444f5302
 DOS3 = 0x444f5303
 DOS4 = 0x444f5304
 DOS5 = 0x444f5305
+DOS6 = 0x444f5306
+DOS7 = 0x444f5307
 
 # more convenient dos type
 DOS_OFS = DOS0
@@ -15,6 +17,8 @@ DOS_OFS_INTL = DOS2
 DOS_FFS_INTL = DOS3
 DOS_OFS_INTL_DIRCACHE = DOS4
 DOS_FFS_INTL_DIRCACHE = DOS5
+DOS_OFS_INTL_LONGNAME = DOS6
+DOS_FFS_INTL_LONGNAME = DOS7
 
 # string names for dos types
 dos_type_names = [
@@ -24,8 +28,8 @@ dos_type_names = [
     'DOS3:ffs+intl',
     'DOS4:ofs+intl+dircache',
     'DOS5:ffs+intl+dircache',
-    'N/A',
-    'N/A'
+    'DOS6:ofs+intl+longname',
+    'DOS7:ffs+intl+longname'
 ]
 
 # masks for modes
@@ -57,7 +61,7 @@ def parse_dos_type_str(string):
     # use 'DOS0' .. 'DOS5'
     if n == 4 and string[0:3] == 'DOS':
       off = ord(string[3]) - ord('0')
-      if off >= 0 and off <= 5:
+      if off >= 0 and off <= 7:
         return DOS0 + off
       else:
         return None
@@ -108,7 +112,7 @@ def get_dos_type_str(dos_type):
 
 def is_valid(dos_type):
   """check if its a valid dos type"""
-  return (dos_type >= DOS0) and (dos_type <= DOS5)
+  return (dos_type >= DOS0) and (dos_type <= DOS7)
 
 def is_ffs(dos_type):
   """check if its a fast file system dostype"""
@@ -116,8 +120,16 @@ def is_ffs(dos_type):
 
 def is_intl(dos_type):
   """check if international mode is enabled in dostype"""
-  return is_dircache(dos_type) or (dos_type & DOS_MASK_INTL) == DOS_MASK_INTL
+  return is_dircache(dos_type) or is_longname(dos_type) or (dos_type & DOS_MASK_INTL) == DOS_MASK_INTL
 
 def is_dircache(dos_type):
   """check if dir cache mode is enabled in dostype"""
-  return (dos_type & DOS_MASK_DIRCACHE) == DOS_MASK_DIRCACHE
+  return (dos_type == DOS4) or (dos_type == DOS5)
+
+def is_longname(dos_type):
+  """check if long filename mode is enabled in dostype"""
+  return (dos_type == DOS6) or (dos_type == DOS7)
+
+def rootblock_tracks_used_blocks(dos_type):
+  """checks if the number of used blocks is stored within the rootblock"""
+  return (dos_type == DOS6) or (dos_type == DOS7)

--- a/amitools/fs/FileName.py
+++ b/amitools/fs/FileName.py
@@ -3,12 +3,13 @@ from FSString import FSString
 class FileName:
   root_path_aliases = (u'', u'/', u':')
   
-  def __init__(self, name, is_intl=False):
+  def __init__(self, name, is_intl=False, is_longname=False):
     # check that name is a FSString
     if not isinstance(name, FSString):
       raise ValueError("FileName's name must be a FSString")
     self.name = name
     self.is_intl = is_intl
+    self.is_longname = is_longname
   
   def __str__(self):
     return self.name
@@ -26,7 +27,7 @@ class FileName:
     pc = self.name.get_unicode().split("/")
     p = []
     for path in pc:
-      p.append(FileName(FSString(path), is_intl=self.is_intl))
+      p.append(FileName(FSString(path), is_intl=self.is_intl, is_longname=self.is_longname))
     return p
   
   def get_dir_and_base_name(self):
@@ -77,7 +78,10 @@ class FileName:
           if o == ':' or o == '/':
             return False
         # check max size
-        if len(s) > 30:
+        if self.is_longname:
+          if len(s) > 110:
+              return False
+        elif len(s) > 30:
             return False
     return True
   

--- a/amitools/fs/block/Block.py
+++ b/amitools/fs/block/Block.py
@@ -18,6 +18,7 @@ class Block:
   T_DATA = 8
   T_LIST = 16
   T_DIR_CACHE = 33
+  T_COMMENT = 64
   # block sub types
   ST_ROOT = 1
   ST_USERDIR = 2
@@ -56,6 +57,9 @@ class Block:
   
   def is_file_data_block(self):
     return self.type == Block.T_DATA
+  
+  def is_comment_block(self):
+    return self.type == Block.T_COMMENT
   
   def read(self):
     if self.data == None:

--- a/amitools/fs/block/CommentBlock.py
+++ b/amitools/fs/block/CommentBlock.py
@@ -1,0 +1,47 @@
+import time
+from Block import Block
+
+class CommentBlock(Block):
+  def __init__(self, blkdev, blk_num):
+    Block.__init__(self, blkdev, blk_num, is_type=Block.T_COMMENT)
+    self.comment = ""
+
+  def create(self, header_key, comment=""):
+    Block.create(self)
+    self.own_key = self.blk_num
+    self.header_key = header_key
+    self.comment = comment
+
+  def set(self, data):
+    self._set_data(data)
+    self._read()
+
+  def read(self):
+    self._read_data()
+    self._read()
+
+  def _read(self):
+    Block.read(self)
+    if not self.valid:
+      return False
+
+    # Comment fields
+    self.own_key = self._get_long(1)
+    self.header_key = self._get_long(2)
+    self.checksum = self._get_long(5)
+    self.comment = self._get_bstr(6, 79)
+    self.valid = (self.own_key == self.blk_num)
+    return self.valid
+
+  def write(self):
+    Block._create_data(self)
+    self._put_long(1, self.own_key)
+    self._put_long(2, self.header_key)
+    self._put_bstr(6, 79, self.comment)
+    Block.write(self)
+
+  def dump(self):
+    Block.dump(self,"Comment")
+    print " own_key:    %d" % (self.own_key)
+    print " header_key: %d" % (self.header_key)
+    print " comment:    '%s'" % self.comment

--- a/amitools/fs/block/EntryBlock.py
+++ b/amitools/fs/block/EntryBlock.py
@@ -1,0 +1,51 @@
+from Block import Block
+from CommentBlock import CommentBlock
+
+class EntryBlock(Block):
+  """Base class for all block types that describe entries within a directory"""
+  def __init__(self, blkdev, blk_num, is_type, is_sub_type, is_longname=False):
+    Block.__init__(self, blkdev, blk_num, is_type, is_sub_type)
+    self.is_longname = is_longname
+    self.comment_block_id = 0
+
+  def _read_nac_modts(self):
+    """Reads the name, comment, and modifcation timestamp"""
+    if self.is_longname:
+      # In long filename mode, we have a combined field that contains
+      # the filename and the comment as consequtive BSTR. If the comment does
+      # not fit in, it is stored in an extra block
+      nac = self._get_cstr(-46,112)
+      name_len = ord(nac[0])
+      self.name = nac[1:name_len+1]
+      if len(nac) > name_len + 1:
+        comment_len = ord(nac[name_len+1])
+        self.comment = nac[name_len+2:name_len+2+comment_len]
+      else:
+        # Comment is located in an extra block
+        self.comment_block_id = self._get_long(-18)
+        self.comment = ""
+      self.mod_ts = self._get_timestamp(-15)
+    else:
+      self.comment = self._get_bstr(-46, 79)
+      self.name = self._get_bstr(-20, 30)
+      self.mod_ts = self._get_timestamp(-23)
+
+  def _write_nac_modts(self):
+    """Writes the name, comment, and modifcation timestamp"""
+    if self.is_longname:
+      if self.comment_block_id != 0:
+        nac = chr(len(self.name)) + self.name + chr(0)
+      else:
+        nac = chr(len(self.name)) + self.name + chr(len(self.comment)) + self.comment
+      self._put_cstr(-46, 122, nac)
+      self._put_long(-18, self.comment_block_id)
+      self._put_timestamp(-15, self.mod_ts)
+    else:
+      self._put_bstr(-46, 79, self.comment)
+      self._put_timestamp(-23, self.mod_ts)
+      self._put_bstr(-20, 30, self.name)
+  
+  @staticmethod
+  def needs_extra_comment_block(name, comment):
+    """Returns whether the given name/comment pair requires an extra comment block"""
+    return len(name) + len(comment) > 110

--- a/amitools/fs/block/FileHeaderBlock.py
+++ b/amitools/fs/block/FileHeaderBlock.py
@@ -1,11 +1,13 @@
 import time
 from Block import Block
+from EntryBlock import EntryBlock
+from CommentBlock import CommentBlock
 from ..ProtectFlags import ProtectFlags
 from ..TimeStamp import *
 
-class FileHeaderBlock(Block):
-  def __init__(self, blkdev, blk_num):
-    Block.__init__(self, blkdev, blk_num, is_type=Block.T_SHORT, is_sub_type=Block.ST_FILE)
+class FileHeaderBlock(EntryBlock):
+  def __init__(self, blkdev, blk_num, is_longname):
+    EntryBlock.__init__(self, blkdev, blk_num, is_type=Block.T_SHORT, is_sub_type=Block.ST_FILE, is_longname=is_longname)
   
   def set(self, data):
     self._set_data(data)
@@ -37,9 +39,7 @@ class FileHeaderBlock(Block):
     self.protect = self._get_long(-48)
     self.protect_flags = ProtectFlags(self.protect)
     self.byte_size = self._get_long(-47)
-    self.comment = self._get_bstr(-46, 79)
-    self.mod_ts = self._get_timestamp(-23)
-    self.name = self._get_bstr(-20, 30)
+    self._read_nac_modts()
     self.hash_chain = self._get_long(-4)
     self.parent = self._get_long(-3)
     self.extension = self._get_long(-2)
@@ -59,9 +59,9 @@ class FileHeaderBlock(Block):
     
     self._put_long(-48, self.protect)
     self._put_long(-47, self.byte_size)
-    self._put_bstr(-46, 79, self.comment)
-    self._put_timestamp(-23, self.mod_ts)
-    self._put_bstr(-20, 30, self.name)
+
+    self._write_nac_modts()
+
     self._put_long(-4, self.hash_chain)
     self._put_long(-3, self.parent)
     self._put_long(-2, self.extension)

--- a/amitools/fs/block/UserDirBlock.py
+++ b/amitools/fs/block/UserDirBlock.py
@@ -1,10 +1,11 @@
 import time
 from Block import Block
+from EntryBlock import EntryBlock
 from ..ProtectFlags import ProtectFlags
 
-class UserDirBlock(Block):
-  def __init__(self, blkdev, blk_num):
-    Block.__init__(self, blkdev, blk_num, is_type=Block.T_SHORT, is_sub_type=Block.ST_USERDIR)
+class UserDirBlock(EntryBlock):
+  def __init__(self, blkdev, blk_num, is_longname):
+    EntryBlock.__init__(self, blkdev, blk_num, is_type=Block.T_SHORT, is_sub_type=Block.ST_USERDIR,is_longname=is_longname)
   
   def set(self, data):
     self._set_data(data)
@@ -22,9 +23,7 @@ class UserDirBlock(Block):
     # UserDir fields
     self.own_key = self._get_long(1)
     self.protect = self._get_long(-48)
-    self.comment = self._get_bstr(-46, 79)
-    self.mod_ts = self._get_timestamp(-23)
-    self.name = self._get_bstr(-20, 30)
+    self._read_nac_modts()
     self.hash_chain = self._get_long(-4)
     self.parent = self._get_long(-3)
     self.extension = self._get_long(-2)
@@ -64,9 +63,7 @@ class UserDirBlock(Block):
     Block._create_data(self)
     self._put_long(1, self.own_key)
     self._put_long(-48, self.protect)
-    self._put_bstr(-46, 79, self.comment)
-    self._put_timestamp(-23, self.mod_ts)
-    self._put_bstr(-20, 30, self.name)
+    self._write_nac_modts()
     self._put_long(-4, self.hash_chain)
     self._put_long(-3, self.parent)
     self._put_long(-2, self.extension)


### PR DESCRIPTION
This PR adds support for the more recent variants of FastFileSystem DOS6 and DOS7 that are supported e.g., in AmigaOS 4.x, into xfdtool. In these variants, the name and comment field for filesystem entries is merged to provide more space for the name. For longer names, the comment is outsourced into a dedicated disk block.
