### PR TITLE
Fix exception when running in Vim

### DIFF
--- a/amitools/tools/xdftool.py
+++ b/amitools/tools/xdftool.py
@@ -32,11 +32,13 @@ def make_fsstr(s):
   # fetch default encoding (if available)
   encoding = sys.stdin.encoding
   if encoding is None:
-    # assume win default encoding
-    if os.platform == "win32":
-      encoding = "cp1252"
-    else:
-      encoding = "utf-8"
+    encoding = "utf-8"
+    try:
+      if os.platform == "win32":
+        # set win default encoding
+        encoding = "cp1252"
+    except AttributeError:
+        pass
   u = s.decode(encoding)
   return FSString(u)
 


### PR DESCRIPTION
If xdftool is run from Vim, an AttributeError is raised because the
"platform" attribute is not defined in the sys module.

This change sets utf8 as the default encoding and then attempts to
access sys.platform and see if we're running windows. If an
AttribueError is raised, it is caught and ignored.