### PR TITLE
add fix-checksum option to copy command

### DIFF
--- a/amitools/rom/KickRom.py
+++ b/amitools/rom/KickRom.py
@@ -85,7 +85,7 @@ class KickRomAccess(RomAccess):
     off = 0
     max_u32 = 0xffffffff
     for i in xrange(num_longs):
-      val = struct.unpack_from(">I", self.rom_data, off)[0]
+      val = struct.unpack_from(">I", buffer(self.rom_data), off)[0]
       if off != skip_off:
         chk_sum += val
       off += 4
@@ -172,7 +172,6 @@ class KickRomAccess(RomAccess):
 
   def get_base_addr(self):
     return self.read_boot_pc() & ~0xffff
-
 
 class Loader(object):
   """Load kick rom images in different formats"""

--- a/amitools/tools/romtool.py
+++ b/amitools/tools/romtool.py
@@ -219,7 +219,7 @@ def do_diff_cmd(args):
   if args.rom_addr:
     base_addr = int(args.rom_addr, 16)
   elif args.show_address:
-    kh = KickRom.Helper(rom_a)
+    kh = KickRom.KickRomAccess(rom_a)
     if kh.is_kick_rom():
       base_addr = kh.get_base_addr()
     else:
@@ -237,7 +237,7 @@ def do_dump_cmd(args):
   if args.rom_addr:
     base_addr = int(args.rom_addr, 16)
   elif args.show_address:
-    kh = KickRom.Helper(rom)
+    kh = KickRom.KickRomAccess(rom)
     if kh.is_kick_rom():
       base_addr = kh.get_base_addr()
     else:

--- a/amitools/tools/romtool.py
+++ b/amitools/tools/romtool.py
@@ -250,10 +250,14 @@ def do_copy_cmd(args):
   in_img = args.in_image
   logging.info("loading ROM from '%s'", in_img)
   rom = KickRom.Loader.load(in_img)
+  kh = KickRomAccess(rom)
+  if args.fix_checksum:
+    kh.make_writable()
+    kh.write_check_sum()
   out_img = args.out_image
   logging.info("saving ROM to '%s'", out_img)
   with open(out_img, "wb") as fh:
-    fh.write(rom)
+    fh.write(kh.get_data())
 
 
 def do_info_cmd(args):
@@ -546,10 +550,8 @@ def setup_scan_parser(parser):
 def setup_copy_parser(parser):
   parser.add_argument('in_image', help='rom image to read')
   parser.add_argument('out_image', help='rom image to be written')
-  parser.add_argument('-b', '--rom-addr', default=None,
-                      help="use this base address for ROM. otherwise guess.")
-  parser.add_argument('-i', '--show-info', default=False, action='store_true',
-                      help="show more details on resident")
+  parser.add_argument('-c', '--fix-checksum', default=False, action='store_true',
+                      help="fix checksum on written image")
   parser.set_defaults(cmd=do_copy_cmd)
 
 

--- a/docs/tools/romtool.rst
+++ b/docs/tools/romtool.rst
@@ -17,6 +17,7 @@ Features
 * concatenate a Kickstart and Ext ROM to a 1 Meg ROM
 * patch a ROM
 * scan a ROM for residents
+* copy a ROM
 
 .. _Remus/Romsplit: http://www.doobreynet.co.uk/
 
@@ -333,3 +334,20 @@ Options:
 
 * ``-o <out_img>`` write generated ROM to given file. Do not forget to specify
   this switch otherwise no output will be generated!
+
+
+``copy`` command
+================
+
+Copy a rom to a new file.  In the future, additional transformations may be
+possible::
+
+  $ romtool copy kick.rom duplicate.rom
+
+Copy ``kick.rom`` to a new ``duplicate.rom`` file.
+
+Options:
+
+* ``-c``, ``--fix-checksum`` after the copy fix the checksum of the written
+image.  For example, if the source rom has been modified with a hex editor or
+a find/replace operation, then this option can be used to correct the checksum.


### PR DESCRIPTION
This adds a -c, --fix-checksum option to the undocumented copy command.  Basically I wanted a way for romtool to fix a checksum on a rom that I had edited externally with a text editor.  This seemed like the best place to add it.