### PR TITLE
Python 3.8 compatibility: fix time.clock()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 env:
   - PIP=pip
@@ -12,6 +14,10 @@ matrix:
   include:
     - os: linux
       python: 3.7
+      dist: xenial
+      sudo: true
+    - os: linux
+      python: 3.8
       dist: xenial
       sudo: true
     - os: osx

--- a/amitools/tools/hunktool.py
+++ b/amitools/tools/hunktool.py
@@ -93,9 +93,9 @@ class HunkCommand:
     path = scan_file.get_path()
     fobj = scan_file.get_fobj()
     hunk_file = HunkReader.HunkReader()
-    start = time.clock()
+    start = time.perf_counter()
     result = hunk_file.read_file_obj(path,fobj)
-    end = time.clock()
+    end = time.perf_counter()
     delta = end - start
     # ignore non hunk files
     if result == Hunk.RESULT_NO_HUNK_FILE:

--- a/amitools/tools/xdfscan.py
+++ b/amitools/tools/xdfscan.py
@@ -19,12 +19,12 @@ from amitools.fs.validate.Progress import Progress
 class MyProgress(Progress):
   def __init__(self):
     Progress.__init__(self)
-    self.clk = int(time.clock() * 1000)
+    self.clk = int(time.perf_counter() * 1000)
   def begin(self, msg):
     Progress.begin(self, msg)
   def add(self):
     Progress.add(self)
-    clk = int(time.clock() * 1000)
+    clk = int(time.perf_counter() * 1000)
     delta = clk - self.clk
     # update display every 250ms
     if delta > 250:

--- a/amitools/vamos/libcore/stub.py
+++ b/amitools/vamos/libcore/stub.py
@@ -199,9 +199,9 @@ class LibStubGen(object):
         call = base_func
 
       def profile_func(this, *args, **kwargs):
-        start = time.clock()
+        start = time.perf_counter()
         call(this, *args, **kwargs)
-        end = time.clock()
+        end = time.perf_counter()
         delta = end - start
         prof.count(delta)
       func = profile_func

--- a/amitools/vamos/machine/machine.py
+++ b/amitools/vamos/machine/machine.py
@@ -456,7 +456,7 @@ class Machine(object):
 
     # main execution loop of run
     total_cycles = 0
-    start_time = time.clock()
+    start_time = time.perf_counter()
     try:
       while not run_state.done:
         log_machine.debug("+ cpu.execute")
@@ -467,7 +467,7 @@ class Machine(object):
           break
     except Exception as e:
       self.error_reporter.report_error(e)
-    end_time = time.clock()
+    end_time = time.perf_counter()
 
     # retrieve regs
     if get_regs:

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py{34,35,36,37}
+envlist = py{34,35,36,37,38}
 skipsdist = {env:TOXBUILD:false}
 
 [travis]
 os =
-    linux: py{34,35,36,37}
-    osx: py{34,35,36,37}
+    linux: py{34,35,36,37,38}
+    osx: py{34,35,36,37,38}
 
 [testenv]
 deps= -rrequirements-test.txt


### PR DESCRIPTION
time.clock() has been deprecated since python 3.3, and was finally removed in python3.8
This PR replaces it with time.perf_counter() so that everything now works again with python 3.8.