### PR TITLE
romtool: Fix 1mb_rom patch on 3.1.4 A500

### DIFF
--- a/amitools/rom/rompatcher.py
+++ b/amitools/rom/rompatcher.py
@@ -26,7 +26,7 @@ class OneMegRomPatch(RomPatch):
 
     def apply_patch(self, access, args=None):
         off = 8
-        while off < 0x400:
+        while off < 0x430:
             v = access.read_long(off)
             if v == 0xF80000:
                 v4 = access.read_long(off + 4)


### PR DESCRIPTION
On Kickstart 3.1.4 A500 the rom header seems to be at 0x41c. Not sure what the right upper limit for the search is here, but 1k is too small.