### PR TITLE
Add options to recover data from a broken RDB disk

### DIFF
--- a/amitools/fs/block/Block.py
+++ b/amitools/fs/block/Block.py
@@ -25,6 +25,8 @@ class Block:
     ST_USERDIR = 2
     ST_FILE = -3 & 0xFFFFFFFF
 
+    ignore_errors = False
+
     def __init__(self, blkdev, blk_num, is_type=0, is_sub_type=0, chk_loc=5):
         self.valid = False
         self.blkdev = blkdev
@@ -36,6 +38,7 @@ class Block:
         self.is_type = is_type
         self.is_sub_type = is_sub_type
         self.chk_loc = chk_loc
+        self.errors = []
 
     def __str__(self):
         return "%s:@%d" % (self.__class__.__name__, self.blk_num)
@@ -70,7 +73,7 @@ class Block:
             self._read_data()
         self._get_types()
         self._get_chksum()
-        self.valid = self.valid_types and self.valid_chksum
+        self.valid = self.valid_types and (self.valid_chksum or Block.ignore_errors)
 
     def write(self):
         if self.data == None:
@@ -129,9 +132,11 @@ class Block:
         self.valid_types = True
         if self.is_type != 0:
             if self.type != self.is_type:
+                self.errors.append("Block #%d type mismatch (is %d but expected %d)" % (self.blk_num, self.type, self.is_type))
                 self.valid_types = False
         if self.is_sub_type != 0:
             if self.sub_type != self.is_sub_type:
+                self.errors.append("Block #%d subtype mismatch (is %d but expected %d)" % (self.blk_num, self.sub_type, self.is_sub_type))
                 self.valid_types = False
 
     def _put_types(self):
@@ -144,6 +149,8 @@ class Block:
         self.got_chksum = self._get_long(self.chk_loc)
         self.calc_chksum = self._calc_chksum()
         self.valid_chksum = self.got_chksum == self.calc_chksum
+        if not self.valid_chksum:
+            self.errors.append("Block #%d checksum is invalid" % (self.blk_num))
 
     def _put_chksum(self):
         self.calc_chksum = self._calc_chksum()

--- a/amitools/fs/rdb/FileSystem.py
+++ b/amitools/fs/rdb/FileSystem.py
@@ -2,6 +2,7 @@ from amitools.fs.block.rdb.FSHeaderBlock import *
 from amitools.fs.block.rdb.LoadSegBlock import *
 from amitools.util.HexDump import *
 import amitools.fs.DosType as DosType
+import logging
 
 
 class FileSystem:
@@ -152,6 +153,12 @@ class FileSystem:
             "size": len(self.data),
             "dev_node": dev_node,
         }
+
+    def log_errors(self):
+        for i in self.lsegs:
+            for e in i.errors:
+                logging.warning(e)
+
 
     # ----- edit -----
 

--- a/amitools/fs/rdb/Partition.py
+++ b/amitools/fs/rdb/Partition.py
@@ -3,16 +3,17 @@ from amitools.fs.block.rdb.PartitionBlock import *
 from amitools.fs.blkdev.PartBlockDevice import PartBlockDevice
 import amitools.util.ByteSize as ByteSize
 import amitools.fs.DosType as DosType
+import logging
 
 
 class Partition:
-    def __init__(self, blkdev, blk_num, num, cyl_blks, rdisk):
+    def __init__(self, blkdev, blk_num, num, cyl_blks, block_bytes, rdisk=None):
         self.blkdev = blkdev
         self.blk_num = blk_num
         self.num = num
         self.cyl_blks = cyl_blks
+        self.block_bytes = block_bytes
         self.rdisk = rdisk
-        self.block_bytes = rdisk.block_bytes
         self.part_blk = None
 
     def get_next_partition_blk(self):
@@ -155,6 +156,11 @@ class Partition:
             "bootable": bootable,
             "automount": automount,
         }
+
+    def log_errors(self):
+        for e in self.part_blk.errors:
+            logging.warning(e)
+
 
     # ----- Import/Export -----
 

--- a/amitools/fs/rdb/Recovery.py
+++ b/amitools/fs/rdb/Recovery.py
@@ -1,0 +1,67 @@
+from amitools.fs.block.rdb.RDBlock import *
+from .FileSystem import FileSystem
+from .Partition import Partition
+from .RDisk import RDisk
+
+class Recovery:
+    def __init__(self, rawblk, block_bytes, cyl_blks, reserved_cyls):
+        self.rawblk = rawblk
+        self.max_blks = cyl_blks * reserved_cyls
+        self.block_bytes = block_bytes
+        self.cyl_blks = cyl_blks
+        self.pnum = 0
+        self.fnum = 0
+
+    def read(self):
+        res = []
+        for i in range(self.max_blks):
+            blk = self.try_block_read(i)
+            if blk is not None:
+                res.append(blk)
+        self.block_map = res
+
+    def try_block_read(self, i):
+        p = Partition(self.rawblk, i, self.pnum, self.cyl_blks, self.block_bytes)
+        if p.read():
+            self.pnum += 1
+            return p
+        f = FileSystem(self.rawblk, i, self.fnum)
+        if f.read():
+            self.fnum += 1
+            return f
+        r = RDBlock(self.rawblk, i)
+        if r.read():
+            return r
+        return None
+
+    def dump(self):
+        for i in self.block_map:
+            print(i.dump())
+
+    def build_rdisk(self):
+        blkdev = self.rawblk
+        rdb = None
+        parts = []
+        fs = []
+        for i in self.block_map:
+            t = type(i)
+            if t is RDBlock:
+                rdb = i
+            if t is Partition:
+                parts.append(i)
+            if t is FileSystem:
+                fs.append(i)
+            pass
+
+        if rdb == None:
+            rdb = RDBlock(blkdev)
+
+        rdisk = RDisk(blkdev)
+        rdisk.create(blkdev.geo, rdb_cyls=self.cyl_blks, blk_num=rdb.blk_num)
+
+        for i in parts:
+            rdisk.parts.append(i)
+        for i in fs:
+            rdisk.fs.append(i)
+
+        return rdisk

--- a/amitools/util/Logging.py
+++ b/amitools/util/Logging.py
@@ -34,5 +34,8 @@ def setup_logging(opts):
             level = logging.INFO
         else:
             level = logging.DEBUG
+    format = FORMAT
+    if opts.log_format is not None:
+        format = opts.log_format
     # setup logging
-    logging.basicConfig(format=FORMAT, filename=opts.log_file, level=level)
+    logging.basicConfig(format=format, filename=opts.log_file, level=level)


### PR DESCRIPTION
## rdbtool
- Add the `ignore-block-errors` option to suppress checksum errors.
- Add the `discover` command to search for known blocks in the RDB area (with the possibility to export found partitions and file systems).
- Replace verbose prints with `logging` library calls.
