### PR TITLE
Small change to fix modern pip3 packaging change breakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.8.1] (2024-05-26)
+
+* Small change to fix modern pip3 packaging change breakage
+
 ## [0.8.0][8] (2024-03-03)
 
 ### global

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
 from setuptools import setup
 
+NAME = "amitools"
+VERSION = "0.8.1"
 
-setup()
+setup(
+  name=NAME,
+  version=VERSION
+)


### PR DESCRIPTION
Sometimes, metadata resolution seems to fail via metadata, resulting in a project name of "unknown", breaking dependencies all kind of ways (in pip 22.0.2 and others), even when installing from the git repository directly.

While users could be asked to upgrade to a newer pip version, this fix addresses the issue without introducing additional problems.