### PR TITLE
romtool relocate: Fixup relocate_one_block() for multiple segments

### DIFF
--- a/amitools/binfmt/Relocate.py
+++ b/amitools/binfmt/Relocate.py
@@ -42,7 +42,7 @@ class Relocate:
         offset = 0
         segs = self.bin_img.get_segments()
         for segment in segs:
-            self._copy_data(data, segment, offset)
+            self._copy_data(data, segment, addrs, offset)
             self._reloc_data(data, segment, addrs, offset)
             offset += segment.size + padding
         return data


### PR DESCRIPTION
When building a rom and If a module contained more than one segment, each segment would be loaded at offset 0

`offset` was being passed into the `addrs` positional var for `_copy_data()`