### PR TITLE
vamos: added graphics.library dummy

### DIFF
--- a/amitools/vamos/lib/GraphicsLibrary.py
+++ b/amitools/vamos/lib/GraphicsLibrary.py
@@ -1,0 +1,4 @@
+from amitools.vamos.libcore import LibImpl
+
+class GraphicsLibrary(LibImpl):
+    pass

--- a/amitools/vamos/lib/LibList.py
+++ b/amitools/vamos/lib/LibList.py
@@ -1,5 +1,6 @@
 from .DosLibrary import DosLibrary
 from .ExecLibrary import ExecLibrary
+from .GraphicsLibrary import GraphicsLibrary
 from .IntuitionLibrary import IntuitionLibrary
 from .LocaleLibrary import LocaleLibrary
 from .MathFFPLibrary import MathFFPLibrary
@@ -10,12 +11,13 @@ from .MathIEEESingTransLibrary import MathIEEESingTransLibrary
 from .MathTransLibrary import MathTransLibrary
 from .TimerDevice import TimerDevice
 from .UtilityLibrary import UtilityLibrary
-from .VamosTestLibrary import VamosTestLibrary
 from .VamosTestDevice import VamosTestDevice
+from .VamosTestLibrary import VamosTestLibrary
 
 vamos_libs = {
     "dos.library": DosLibrary,
     "exec.library": ExecLibrary,
+    "graphics.library": GraphicsLibrary,
     "intuition.library": IntuitionLibrary,
     "locale.library": LocaleLibrary,
     "mathffp.library": MathFFPLibrary,
@@ -26,6 +28,6 @@ vamos_libs = {
     "mathtrans.library": MathTransLibrary,
     "timer.device": TimerDevice,
     "utility.library": UtilityLibrary,
-    "vamostest.library": VamosTestLibrary,
     "vamostestdev.device": VamosTestDevice,
+    "vamostest.library": VamosTestLibrary,
 }


### PR DESCRIPTION
Add empty graphics.library to the available tagged libraries.

This fixes the startup code for Amiga E: https://strlen.com/amiga-e/ and make the "Hello world!" example in the Beginners Guide work.