### PR TITLE
Fix ReadEClock

### DIFF
--- a/amitools/vamos/lib/TimerDevice.py
+++ b/amitools/vamos/lib/TimerDevice.py
@@ -12,9 +12,9 @@ class TimerDevice(LibImpl):
 
         dt = datetime.now()
 
-        # abuse DateStampStruct
+        # abuse DateStampStruct (ds_Days -> ev_hi, ds_Minute -> ev_lo)
         tv = AccessStruct(ctx.mem, DateStampStruct, struct_addr=eclockval)
-        tv.ds_Days = dt.microsecond / 1000000
-        tv.ds_Minute = dt.microsecond % 1000000
+        tv.w_s("ds_Days", dt.microsecond // 1000000)
+        tv.w_s("ds_Minute", dt.microsecond % 1000000)
 
         return 50


### PR DESCRIPTION
In TimerDevice.py:

  tv.ds_Days = dt.microsecond / 1000000
  tv.ds_Minute = dt.microsecond % 1000000

The problem is that AccessStruct doesn't support direct attribute assignment.
These lines are just setting Python object attributes on tv, not writing to
emulated memory. You need to use the w_s() method:

  tv.w_s("ds_Days", int(dt.microsecond / 1000000))
  tv.w_s("ds_Minute", dt.microsecond % 1000000)
