### PR TITLE
fs/rdb: fix partition deletion corrupting RDB linked list

### DIFF
--- a/amitools/fs/rdb/RDisk.py
+++ b/amitools/fs/rdb/RDisk.py
@@ -697,9 +697,9 @@ class RDisk:
         if pid == 0:
             self.rdb.part_list = next
         else:
-            last_pb = self.parts[-1]
-            last_pb.part_blk.next = next
-            last_pb.write()
+            prev_pb = self.parts[pid - 1]
+            prev_pb.part_blk.next = next
+            prev_pb.write()
         # free block
         p = self.parts[pid]
         blk_num = p.get_blk_num()


### PR DESCRIPTION
When deleting a partition that is not the first one, the code
incorrectly updates the 'next' pointer of the last partition in the
array (self.parts[-1]) instead of the partition immediately preceding
the one being deleted (self.parts[pid - 1]).

This causes two failure modes:
  - Deleting the last partition silently fails as it updates its own
    next pointer before removal
  - Deleting any other non-first partition corrupts the RDB structure
    by breaking the linked list chain, causing subsequent operations
    to hang or fail

Fix by updating the correct predecessor partition's next pointer to
maintain proper linked list integrity. Fix written by Bernie Innocenti.

Fixes: https://github.com/cnvogelg/amitools/issues/218
