### PR TITLE
dos: add Latin-1 to UTF-8 conversion for stdout

### DIFF
--- a/amitools/vamos/lib/dos/FileHandle.py
+++ b/amitools/vamos/lib/dos/FileHandle.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 from amitools.vamos.libstructs import FileHandleStruct
-from .terminal import Terminal
+from .terminal import Terminal, Latin1ToUtf8Converter
 
 
 class FileHandle:
@@ -28,6 +28,13 @@ class FileHandle:
             self.terminal = Terminal(obj)
         else:
             self.terminal = None
+        # Latin-1 to UTF-8 conversion for non-terminal stdout
+        enc = sys.stdout.encoding
+        is_utf8 = enc and enc.lower().replace("-", "") == "utf8"
+        if not self.interactive and obj == sys.stdout.buffer and is_utf8:
+            self.latin1_conv = Latin1ToUtf8Converter()
+        else:
+            self.latin1_conv = None
 
     def __repr__(self):
         return "[FH:'%s'(ami='%s',sys='%s',nc=%s,af=%s,int=%s)@%06x=B@%06x]" % (
@@ -86,13 +93,18 @@ class FileHandle:
 
         return -1 on error, 0=EOF, >0 written bytes"""
         assert isinstance(data, (bytes, bytearray))
+        orig_len = len(data)
 
         # read from terminal or direct
         if self.terminal:
             got = self.terminal.write(data)
         else:
+            # do Latin-1 to UTF-8 conversion if needed
+            if self.latin1_conv:
+                data = self.latin1_conv.convert(data)
             try:
-                got = self.obj.write(data)
+                self.obj.write(data)
+                got = orig_len
             except IOError:
                 got = -1
 

--- a/amitools/vamos/lib/dos/terminal.py
+++ b/amitools/vamos/lib/dos/terminal.py
@@ -9,6 +9,7 @@ except ImportError:
     select = None
 
 import io
+import sys
 
 ESC = b"\x1b"
 ESC_CODE = 0x1B
@@ -20,6 +21,11 @@ CSI_ESC_SEQ = b"\x1b\x5b"
 class CsiEscConverter:
     def convert(self, buffer):
         return buffer.replace(CSI, CSI_ESC_SEQ)
+
+
+class Latin1ToUtf8Converter:
+    def convert(self, buffer):
+        return buffer.decode("latin-1").encode("utf-8")
 
 
 class EscCsiConverter:
@@ -124,6 +130,12 @@ class Terminal:
         else:
             self.in_conv = None
 
+        # convert Latin-1 to UTF-8 if stdout uses UTF-8 encoding
+        if sys.stdout.encoding and sys.stdout.encoding.lower().replace("-", "") == "utf8":
+            self.latin1_conv = Latin1ToUtf8Converter()
+        else:
+            self.latin1_conv = None
+
     def close(self):
         if termios:
             termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.tty_state)
@@ -184,12 +196,18 @@ class Terminal:
 
         return -1 on Error, 0 on EOF, and >0 written bytes
         """
+        orig_len = len(data)
 
         # do CSI to ESC conversion
         if self.out_conv:
             data = self.out_conv.convert(data)
 
+        # do Latin-1 to UTF-8 conversion
+        if self.latin1_conv:
+            data = self.latin1_conv.convert(data)
+
         try:
-            return self.obj.write(data)
+            self.obj.write(data)
+            return orig_len
         except IOError:
             return -1


### PR DESCRIPTION
Amiga programs use Latin-1 (ISO-8859-1) encoding for text output, but
modern terminals typically expect UTF-8. Without conversion, extended
characters (codes 128-255) display incorrectly.

Add Latin1ToUtf8Converter class and use it in both Terminal and
FileHandle write paths when the system stdout uses UTF-8 encoding.

Also fix write() return value to report the original byte count rather
than the converted byte count, as callers expect the number of Amiga
bytes written.
