### PR TITLE
Updates to GetVar/SetVar/DeleteVar - new functionality and bug fixes

### DIFF
--- a/amitools/vamos/cfg/proc.py
+++ b/amitools/vamos/cfg/proc.py
@@ -13,6 +13,7 @@ class ProcessParser(Parser):
                     "mode": Value(str, "proc"),
                 },
                 "stack": 8,
+                "vars": ValueList(str, allow_split=False),
             }
         }
         arg_cfg = {
@@ -52,6 +53,11 @@ class ProcessParser(Parser):
                     type=int,
                     help="set stack size in KiB",
                 ),
+                "vars": Argument(
+                    "--set-var",
+                    action="append",
+                    help="set an AmigaDOS local variable: name=value",
+                ),
             }
         }
         ini_trafo = {
@@ -62,6 +68,7 @@ class ProcessParser(Parser):
                     "raw_arg": "raw_arg",
                 },
                 "stack": "stack_size",
+                "vars": "vars",
             }
         }
         Parser.__init__(

--- a/amitools/vamos/lib/DosLibrary.py
+++ b/amitools/vamos/lib/DosLibrary.py
@@ -70,6 +70,7 @@ class DosLibrary(LibImpl):
         self.errstrings = {}
         self.resident = []
         self.local_vars = {}
+        self.global_vars = {}
         self.access = AccessStruct(ctx.mem, self.get_struct_def(), base_addr)
         # setup RootNode
         self.root_struct = ctx.alloc.alloc_struct(RootNodeStruct, label="RootNode")
@@ -410,6 +411,20 @@ class DosLibrary(LibImpl):
                     log_dos.info('GetVar("%s", 0x%x) -> %s', name, flags, value)
                     self.setioerr(ctx, len(value))
                     return min(nodelen - 1, size - 1)
+        # no local variable. unless we were asked for local only, fall back
+        # to the global ones, which is the order AmigaOS looks them up in
+        if not flags & self.GVF_LOCAL_ONLY:
+            value = self.global_vars.get((name.lower(), flags & 0xFF))
+            if value is not None:
+                if flags & self.GVF_BINARY_VAR:
+                    ctx.mem.write_data(buff_ptr, value[:size])
+                    log_dos.info('GetVar("%s", 0x%x) -> <global binary>', name, flags)
+                    self.setioerr(ctx, len(value))
+                    return min(len(value), size)
+                ctx.mem.w_cstr(buff_ptr, value[: size - 1])
+                log_dos.info('GetVar("%s", 0x%x) -> %s (global)', name, flags, value)
+                self.setioerr(ctx, len(value))
+                return min(len(value), size - 1)
         self.setioerr(ctx, ERROR_OBJECT_NOT_FOUND)
         return -1
 
@@ -434,11 +449,13 @@ class DosLibrary(LibImpl):
         name = ctx.mem.r_cstr(name_ptr)
         vtype = flags & 0xFF
         if buff_ptr == 0:
-            if not flags & self.GVF_GLOBAL_ONLY:
-                node = self.find_var(ctx, name, vtype)
-                if node != None:
-                    self.delete_var(ctx, node)
+            if flags & self.GVF_GLOBAL_ONLY:
+                self.global_vars.pop((name.lower(), vtype), None)
                 return DOSTRUE
+            node = self.find_var(ctx, name, vtype)
+            if node != None:
+                self.delete_var(ctx, node)
+            return DOSTRUE
         else:
             if flags & self.GVF_BINARY_VAR:
                 value = None
@@ -447,25 +464,32 @@ class DosLibrary(LibImpl):
                 value = ctx.mem.r_cstr(buff_ptr)
                 log_dos.info('SetVar("%s") to %s', name, value)
                 size = len(value) + 1
-            if not flags & self.GVF_GLOBAL_ONLY:
-                node = self.find_var(ctx, name, flags)
-                if node == None and buff_ptr != 0:
-                    node = self.create_var(ctx, name, flags)
-                if node != None:
-                    self.set_var(ctx, node, buff_ptr, size, value, flags)
+            if flags & self.GVF_GLOBAL_ONLY:
+                if flags & self.GVF_BINARY_VAR:
+                    value = ctx.mem.read_data(buff_ptr, size)
+                self.global_vars[(name.lower(), vtype)] = value
                 return DOSTRUE
+            node = self.find_var(ctx, name, flags)
+            if node == None and buff_ptr != 0:
+                node = self.create_var(ctx, name, flags)
+            if node != None:
+                self.set_var(ctx, node, buff_ptr, size, value, flags)
+            return DOSTRUE
         return 0
 
     def DeleteVar(self, ctx):
         name_ptr = ctx.cpu.r_reg(REG_D1)
         flags = ctx.cpu.r_reg(REG_D4)
         name = ctx.mem.r_cstr(name_ptr)
-        if not flags & self.GVF_GLOBAL_ONLY:
-            node = self.find_var(ctx, name, flags)
-            log_dos.info('DeleteVar("%s")', name)
-            if node != None:
-                self.delete_var(ctx, node)
-            return DOSTRUE
+        if flags & self.GVF_GLOBAL_ONLY:
+            found = self.global_vars.pop((name.lower(), flags & 0xFF), None)
+            log_dos.info('DeleteVar("%s") global', name)
+            return DOSTRUE if found is not None else DOSFALSE
+        node = self.find_var(ctx, name, flags)
+        log_dos.info('DeleteVar("%s")', name)
+        if node != None:
+            self.delete_var(ctx, node)
+        return DOSTRUE
 
     # ----- Signals ----------------------
 

--- a/amitools/vamos/lib/DosLibrary.py
+++ b/amitools/vamos/lib/DosLibrary.py
@@ -386,7 +386,7 @@ class DosLibrary(LibImpl):
         flags = ctx.cpu.r_reg(REG_D4)
         if size == 0:
             self.setioerr(ctx, ERROR_BAD_NUMBER)
-            return DOSFALSE
+            return -1
         name = ctx.mem.r_cstr(name_ptr)
         if not flags & self.GVF_GLOBAL_ONLY:
             node = self.find_var(ctx, name, flags & 0xFF)
@@ -410,7 +410,8 @@ class DosLibrary(LibImpl):
                     log_dos.info('GetVar("%s", 0x%x) -> %s', name, flags, value)
                     self.setioerr(ctx, len(value))
                     return min(nodelen - 1, size - 1)
-        return DOSFALSE
+        self.setioerr(ctx, ERROR_OBJECT_NOT_FOUND)
+        return -1
 
     def FindVar(self, ctx):
         name_ptr = ctx.cpu.r_reg(REG_D1)

--- a/amitools/vamos/mode/proc.py
+++ b/amitools/vamos/mode/proc.py
@@ -50,7 +50,35 @@ class ProcMode(BaseMode):
         )
         if not proc.ok:
             return None
+        self.setup_vars(dos_ctx, proc, proc_cfg.vars)
         return proc
+
+    def setup_vars(self, dos_ctx, proc, var_specs):
+        """seed the process with AmigaDOS local variables.
+
+        The emulated program starts with an empty variable table, so a
+        program that expects one set by the shell, e.g. with "Set NAME
+        value", has no way of seeing it.  Variables named here are put in
+        place before the program runs, as that Set would have done.
+        """
+        if not var_specs:
+            return
+        dos_lib = dos_ctx.dos_lib
+        # create_var() works on the current process, which is only set
+        # once the task is scheduled, so point at ours for the duration
+        old_proc = dos_ctx.process
+        dos_ctx.set_cur_process(proc)
+        try:
+            for spec in var_specs:
+                if "=" in spec:
+                    name, value = spec.split("=", 1)
+                else:
+                    name, value = spec, ""
+                node = dos_lib.create_var(dos_ctx, name, 0)
+                dos_lib.set_var(dos_ctx, node, 0, len(value) + 1, value, 0)
+                log_proc.info("set var: %s='%s'", name, value)
+        finally:
+            dos_ctx.set_cur_process(old_proc)
 
     def get_cmd_args(self, mode_ctx, cmd_cfg, args):
         # a single Amiga-like raw arg was passed

--- a/test/unit/cfg_proc.py
+++ b/test/unit/cfg_proc.py
@@ -14,6 +14,7 @@ def cfg_proc_dict_test():
                 "mode": "proc",
             },
             "stack": 4,
+            "vars": [],
         }
     }
     lp.parse_config(input_dict, "dict")
@@ -41,6 +42,7 @@ def cfg_proc_ini_test():
                 "mode": "proc",
             },
             "stack": 4,
+            "vars": None,
         }
     }
 
@@ -50,7 +52,7 @@ def cfg_proc_args_test():
     ap = argparse.ArgumentParser()
     lp.setup_args(ap)
     args = ap.parse_args(
-        ["-x", "-P", "-R", "-s", "4", "foo", "a", "b", "c,d", "(e)", "*f"]
+        ["-x", "-P", "-R", "-s", "4", "foo", "a", "b", "c,d", "(e)", "*f", "--set-var", "FOO=BAR", "--set-var", "BAZ=QUX"]
     )
     lp.parse_args(args)
     assert lp.get_cfg_dict() == {
@@ -63,5 +65,6 @@ def cfg_proc_args_test():
                 "mode": "proc",
             },
             "stack": 4,
+            "vars": ["FOO=BAR", "BAZ=QUX"],
         }
     }


### PR DESCRIPTION
This PR adds these changes to emulator DOS environment variables:

* environment variables can be added to the Amiga process by passing `--set-var` command line option to vamos.
* global environment variables are supported, when the emulated process requests them (previously, SetVar would ignore a request to create a global variable).
* GetVar() was returning the wrong value when a variable was not set - should be `-1` not `DOSFALSE`.

I am working on a reboot of the DICE C Compiler - my work is at https://github.com/dice-nx/dice-nx - and these changes fix problems that prevents DICE-nx from running under vamos.

Full disclosure - Claude Code assisted me in debugging the issues and writing this code, however I was "driving" and reviewed all code changes. Please let me know if this is a problem.